### PR TITLE
Add ability to set x-amz-acl header as part of S3Upload call

### DIFF
--- a/s3upload.js
+++ b/s3upload.js
@@ -3,6 +3,8 @@
     S3Upload.prototype.s3_sign_put_url = '/signS3put';
 
     S3Upload.prototype.file_dom_selector = '#file_upload';
+    
+    S3Upload.prototype.acl_value = 'public-read'
 
     S3Upload.prototype.onFinishS3Put = function(public_url, file) {
       return console.log('base.onFinishS3Put()', public_url, file);
@@ -111,7 +113,7 @@
         };
       }
       xhr.setRequestHeader('Content-Type', type);
-      xhr.setRequestHeader('x-amz-acl', 'public-read');
+      xhr.setRequestHeader('x-amz-acl', this.acl_value);
       return xhr.send(file);
     };
 


### PR DESCRIPTION
This PR adds the ability to set the acl value in the parameters when calling S3Upload instead of having it always be `public-read`. This way, we can specify when we want to upload something to a private bucket. 