### PR TITLE
Add acl value to params for calling s3_sign_put_url

### DIFF
--- a/s3upload.js
+++ b/s3upload.js
@@ -65,7 +65,7 @@
       xhr = new XMLHttpRequest();
       type = opts && opts.type || file.type || "application/octet-stream";
       name = opts && opts.name || file.name;
-      xhr.open('GET', this.s3_sign_put_url + '?s3_object_type=' + type + '&s3_object_name=' + encodeURIComponent(name), true);
+      xhr.open('GET', this.s3_sign_put_url + '?s3_object_type=' + type + '&s3_object_name=' + encodeURIComponent(name) + '&acl_value=' + this.acl_value, true);
       xhr.overrideMimeType('text/plain; charset=x-user-defined');
       xhr.onreadystatechange = function(e) {
         var error, result;


### PR DESCRIPTION
Follow-up to #1 -- Now that we allow for a custom ACL value and don't just assume a file is public, we also need to send that to the BE, otherwise, you won't be able to access the ACL value to sign the s3 put with. 